### PR TITLE
WCP-313 - Move some dev dependencies to dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+v2.3.0
+------------------------------
+*March 10, 2020*
+
+### Changed
+-   Move dev dependencies for stylelint packages into dependencies, so they get pulled in by consumers
+
+
 v2.2.0
 ------------------------------
 *March 09, 2020*

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justeat/stylelint-config-fozzie",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Shareable Stylelint config for use with Fozzie – Just Eats UI Component Framework",
   "keywords": [
     "stylelint",
@@ -17,6 +17,11 @@
   "files": [
     "index.js"
   ],
+  "dependencies": {
+    "stylelint": "13.2.0",
+    "stylelint-order": "4.0.0",
+    "stylelint-scss": "3.14.2"
+  },
   "devDependencies": {
     "@justeat/eslint-config-fozzie": "3.4.0",
     "danger": "9.2.10",
@@ -25,10 +30,7 @@
     "jest": "25.1.0",
     "npm-run-all": "4.1.5",
     "remark-cli": "7.0.1",
-    "remark-preset-lint-recommended": "3.0.3",
-    "stylelint": "13.2.0",
-    "stylelint-order": "4.0.0",
-    "stylelint-scss": "3.14.2"
+    "remark-preset-lint-recommended": "3.0.3"
   },
   "peerDependencies": {
     "stylelint": "13.2.0",


### PR DESCRIPTION
**Updated**
- `stylelint` packages need to be dependencies so they get pulled in by consumers.